### PR TITLE
Fix explicit any type error in avatar component

### DIFF
--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -8,7 +8,7 @@ import Image from "next/image"
 const Avatar = React.forwardRef<
   React.ElementRef<"span">,
   React.ComponentPropsWithoutRef<"span">
->(({ className, ...props }, ref) => (
+>(({ className, ...props }: React.ComponentPropsWithoutRef<"span">, ref: React.Ref<React.ElementRef<"span">>) => (
   <span
     ref={ref}
     data-slot="avatar"
@@ -24,9 +24,9 @@ Avatar.displayName = "Avatar"
 const AvatarImage = React.forwardRef<
   React.ElementRef<typeof Image>,
   Omit<React.ComponentProps<typeof Image>, "fill"> & { src: string; alt?: string }
->(({ className, alt = "", src, ...props }, ref) => (
+>(({ className, alt = "", src, ...props }: Omit<React.ComponentProps<typeof Image>, "fill"> & { src: string; alt?: string }, ref: React.Ref<React.ElementRef<typeof Image>>) => (
   <Image
-    ref={ref as any}
+    ref={ref}
     src={src}
     alt={alt}
     fill
@@ -40,7 +40,7 @@ AvatarImage.displayName = "AvatarImage"
 const AvatarFallback = React.forwardRef<
   React.ElementRef<"span">,
   React.ComponentPropsWithoutRef<"span">
->(({ className, ...props }, ref) => (
+>(({ className, ...props }: React.ComponentPropsWithoutRef<"span">, ref: React.Ref<React.ElementRef<"span">>) => (
   <span
     ref={ref}
     className={cn(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
         "name": "next"
       }
     ],
-    "types": ["node"],
+    "types": ["node", "react", "react-dom"],
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
Explicitly type `forwardRef` parameters and add React types to `tsconfig.json` to resolve `@typescript-eslint/no-explicit-any` errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-6838832a-004a-48f0-863b-91e18ad443cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6838832a-004a-48f0-863b-91e18ad443cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

